### PR TITLE
SLAM images added + fixed input for add-apt-repo in dockerfile.libs

### DIFF
--- a/base-gpu-notebook/Dockerfile.libs
+++ b/base-gpu-notebook/Dockerfile.libs
@@ -7,7 +7,7 @@ USER root
 RUN apt-get update && \
     apt-get install -y libgl1-mesa-dev vim htop curl software-properties-common && \
     apt-get install -y cmake libncurses5-dev libncursesw5-dev git sox && \
-    add-apt-repository ppa:flexiondotorg/nvtop && \
+    add-apt-repository -y ppa:flexiondotorg/nvtop && \
     apt-get install -y nvtop zip && \
     rm -rf /var/lib/apt/lists/*
 

--- a/base-gpu-notebook/gcnv2/Dockerfile
+++ b/base-gpu-notebook/gcnv2/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:gcn_v2

--- a/base-gpu-notebook/openvins/Dockerfile
+++ b/base-gpu-notebook/openvins/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:open_vins

--- a/base-gpu-notebook/orb2/Dockerfile
+++ b/base-gpu-notebook/orb2/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:orb2_youyu

--- a/base-gpu-notebook/orb3/Dockerfile
+++ b/base-gpu-notebook/orb3/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:orb3_sacrover

--- a/base-gpu-notebook/pykitti/Dockerfile
+++ b/base-gpu-notebook/pykitti/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:pykitti_kitti2bag

--- a/base-gpu-notebook/rtabhumble/Dockerfile
+++ b/base-gpu-notebook/rtabhumble/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:rtab_humble

--- a/base-gpu-notebook/rtabnoetic/Dockerfile
+++ b/base-gpu-notebook/rtabnoetic/Dockerfile
@@ -1,0 +1,1 @@
+ARG ROOT_CONTAINER=maziz70/slam:rtab_noetic


### PR DESCRIPTION
Changes: 
1. New SLAM algorithm images added to base-gpu-notebook folder with related docker hub image
2. A small modification (adding -y parameter) on below line was done to fix user input problem while running inside docker container:
https://github.com/a2s-institute/docker-stacks/blob/d7f8c38f1818f5751d367f840c0fc369773813c3/base-gpu-notebook/Dockerfile.libs#L10