### PR TITLE
Add ROS2 Kilted CUDA 12 image with Gazebo and MuJoCo support

### DIFF
--- a/images/ros/cuda12-kilted/Dockerfile
+++ b/images/ros/cuda12-kilted/Dockerfile
@@ -1,0 +1,53 @@
+ARG BASE_IMAGE=quay.io/a2s-institute/base-gpu-notebook:cuda12-ubuntu24.04
+FROM $BASE_IMAGE
+LABEL maintainer="A2S Institute <robotics@h-brs.de>"
+
+USER root
+
+# Locale
+RUN set -eux; \
+    locale; \
+    locale-gen en_US en_US.UTF-8; \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8; \
+    export LANG=en_US.UTF-8; \
+    locale
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# Basic deps
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    locales \
+    software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN add-apt-repository universe && apt-get update -y
+
+# ROS 2 apt source
+RUN set -eux; \
+    ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest \
+      | grep -F "tag_name" \
+      | awk -F\" '{print $4}'); \
+    UBUNTU_CODENAME=$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}}); \
+    curl -L -o /tmp/ros2-apt-source.deb \
+      "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.${UBUNTU_CODENAME}_all.deb"; \
+    dpkg -i /tmp/ros2-apt-source.deb; \
+    rm /tmp/ros2-apt-source.deb; \
+    apt-get update -y
+
+# ROS 2 Kilted + colcon + Gazebo bridge + MuJoCo
+RUN apt-get update -y && \
+    apt-get install -y \
+      ros-kilted-desktop \
+      python3-colcon-common-extensions \
+      ros-kilted-ros-gz \
+      libmujoco2.2.2 \
+      libmujoco-dev && \
+    echo "source /opt/ros/kilted/setup.bash" >> /home/${NB_USER}/.bashrc && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $NB_USER


### PR DESCRIPTION
New ROS 2 Kilted Kaiju builds on top of Ubuntu 24.04. This Dockerfile provides the possibility to have a GPU-enabled Docker image with installed ROS2 Kilted, along with Gazebo and MuJuCo